### PR TITLE
Add one_vnet module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,8 @@ cd ~/dev/ansible_collections/community/general
 
 Then you can run `ansible-test` (which is a part of [ansible-core](https://pypi.org/project/ansible-core/)) inside the checkout. The following example commands expect that you have installed Docker or Podman. Note that Podman has only been supported by more recent ansible-core releases. If you are using Docker, the following will work with Ansible 2.9+.
 
+### Sanity tests
+
 The following commands show how to run sanity tests:
 
 ```.bash
@@ -65,6 +67,8 @@ ansible-test sanity --docker -v
 # Run sanity tests for the given files and directories:
 ansible-test sanity --docker -v plugins/modules/system/pids.py tests/integration/targets/pids/
 ```
+
+### Unit tests
 
 The following commands show how to run unit tests:
 
@@ -79,13 +83,32 @@ ansible-test units --docker -v --python 3.8
 ansible-test units --docker -v --python 3.8 tests/unit/plugins/modules/net_tools/test_nmcli.py
 ```
 
+### Integration tests
+
 The following commands show how to run integration tests:
 
-```.bash
-# Run integration tests for the interfaces_files module in a Docker container using the
-# fedora35 operating system image (the supported images depend on your ansible-core version):
-ansible-test integration --docker fedora35 -v interfaces_file
+#### In Docker
 
+Integration tests on Docker have the following parameters:
+- `image_name` (required): The name of the Docker image. To get the list of supported Docker images, run
+  `ansible-test integration --help` and look for _target docker images_.
+- `test_name` (optional): The name of the integration test.  
+  For modules, this equals the short name of the module; for example, `pacman` in case of `community.general.pacman`.  
+  For plugins, the plugin type is added before the plugin's short name, for example `callback_yaml` for the `community.general.yaml` callback.
+```.bash
+# Test all plugins/modules on fedora40
+ansible-test integration -v --docker fedora40
+
+# Template
+ansible-test integration -v --docker image_name test_name
+
+# Example community.general.ini_file module on fedora40 Docker image:
+ansible-test integration -v --docker fedora40 ini_file
+```
+
+#### Without isolation
+
+```.bash
 # Run integration tests for the flattened lookup **without any isolation**:
 ansible-test integration -v lookup_flattened
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you encounter abusive behavior violating the [Ansible Code of Conduct](https:
 ## Communication
 
 * Join the Ansible forum:
-  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others. This is for questions about modules or plugins in the collection.
+  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others. This is for questions about modules or plugins in the collection. Please add appropriate tags if you start new discussions.
   * [Tag `community-general`](https://forum.ansible.com/tag/community-general): discuss the *collection itself*, instead of specific modules or plugins.
   * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
   * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ We follow [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/comm
 
 If you encounter abusive behavior violating the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html), please refer to the [policy violations](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html#policy-violations) section of the Code of Conduct for information on how to raise a complaint.
 
+## Communication
+
+* Join the Ansible forum:
+  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others. This is for questions about modules or plugins in the collection.
+  * [Tag `community-general`](https://forum.ansible.com/tag/community-general): discuss the *collection itself*, instead of specific modules or plugins.
+  * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+
+* The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
+
+For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
 ## Tested with Ansible
 
 Tested with the current ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, ansible-core 2.17 releases and the current development version of ansible-core. Ansible-core versions before 2.13.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
@@ -97,18 +109,6 @@ It is necessary for maintainers of this collection to be subscribed to:
 * The "Changes Impacting Collection Contributors and Maintainers" [issue](https://github.com/ansible-collections/overview/issues/45).
 
 They also should be subscribed to Ansible's [The Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
-
-## Communication
-
-We announce important development changes and releases through Ansible's [The Bullhorn newsletter](https://eepurl.com/gZmiEP). If you are a collection developer, be sure you are subscribed.
-
-Join us in the `#ansible` (general use questions and support), `#ansible-community` (community and collection development questions), and other [IRC channels](https://docs.ansible.com/ansible/devel/community/communication.html#irc-channels) on [Libera.chat](https://libera.chat).
-
-We take part in the global quarterly [Ansible Contributor Summit](https://github.com/ansible/community/wiki/Contributor-Summit) virtually or in-person. Track [The Bullhorn newsletter](https://eepurl.com/gZmiEP) and join us.
-
-For more information about communities, meetings and agendas see [Community Wiki](https://github.com/ansible/community/wiki/Community).
-
-For more information about communication, refer to Ansible's the [Communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
 
 ## Publishing New Version
 

--- a/changelogs/fragments/8674-add-gitlab-project-cleanup-policy.yml
+++ b/changelogs/fragments/8674-add-gitlab-project-cleanup-policy.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - gitlab_project - add option ``repository_access_level`` to disable project repository (https://github.com/ansible-collections/community.general/pull/8674).
+  - gitlab_project - add option ``container_expiration_policy`` to schedule container registry cleanup (https://github.com/ansible-collections/community.general/pull/8674).

--- a/changelogs/fragments/8675-pipx-install-suffix.yml
+++ b/changelogs/fragments/8675-pipx-install-suffix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pipx - add parameter ``suffix`` to module (https://github.com/ansible-collections/community.general/pull/8675, https://github.com/ansible-collections/community.general/issues/8656).

--- a/changelogs/fragments/8682-locale-gen-multiple.yaml
+++ b/changelogs/fragments/8682-locale-gen-multiple.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - locale_gen - add support for multiple locales (https://github.com/ansible-collections/community.general/issues/8677, https://github.com/ansible-collections/community.general/pull/8682).

--- a/changelogs/fragments/8688-gitlab_project-add-new-params.yml
+++ b/changelogs/fragments/8688-gitlab_project-add-new-params.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - gitlab_project - add option ``pages_access_level`` to disable project pages (https://github.com/ansible-collections/community.general/pull/8688).
+  - gitlab_project - add option ``service_desk_enabled`` to disable service desk (https://github.com/ansible-collections/community.general/pull/8688).
+  - gitlab_project - add option ``model_registry_access_level`` to disable model registry (https://github.com/ansible-collections/community.general/pull/8688).

--- a/changelogs/fragments/8689-passwordstore-lock-naming.yml
+++ b/changelogs/fragments/8689-passwordstore-lock-naming.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - passwordstore lookup plugin - add the current user to the lockfile file name to address issues on multi-user systems (https://github.com/ansible-collections/community.general/pull/8689).

--- a/changelogs/fragments/8695-keycloak_user_federation-mapper-removal.yml
+++ b/changelogs/fragments/8695-keycloak_user_federation-mapper-removal.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_user_federation - remove existing user federation mappers if they are not present in the federation configuration and will not be updated (https://github.com/ansible-collections/community.general/issues/7169, https://github.com/ansible-collections/community.general/pull/8695).

--- a/changelogs/fragments/8708-homebrew_cask-fix-upgrade-all.yml
+++ b/changelogs/fragments/8708-homebrew_cask-fix-upgrade-all.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew_cask - fix ``upgrade_all`` returns ``changed`` when nothing upgraded (https://github.com/ansible-collections/community.general/issues/8707, https://github.com/ansible-collections/community.general/pull/8708).

--- a/changelogs/fragments/8713-proxmox_lxc_interfaces.yml
+++ b/changelogs/fragments/8713-proxmox_lxc_interfaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox inventory plugin - add new fact for LXC interface details (https://github.com/ansible-collections/community.general/pull/8713).

--- a/changelogs/fragments/8735-keycloak_identity_provider-get-cleartext-secret-from-realm-info.yml
+++ b/changelogs/fragments/8735-keycloak_identity_provider-get-cleartext-secret-from-realm-info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_user_federation - get cleartext IDP ``clientSecret`` from full realm info to detect changes to it (https://github.com/ansible-collections/community.general/issues/8294, https://github.com/ansible-collections/community.general/pull/8735).

--- a/changelogs/fragments/8741-fix-opentelemetry-callback.yml
+++ b/changelogs/fragments/8741-fix-opentelemetry-callback.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - opentelemetry callback plugin - fix default value for ``store_spans_in_file`` causing traces to be produced to a file named ``None`` (https://github.com/ansible-collections/community.general/issues/8566, https://github.com/ansible-collections/community.general/pull/8741).

--- a/changelogs/fragments/8759-gitlab_project-sort-params.yml
+++ b/changelogs/fragments/8759-gitlab_project-sort-params.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab_project - sorted parameters in order to avoid future merge conflicts (https://github.com/ansible-collections/community.general/pull/8759).

--- a/docs/docsite/links.yml
+++ b/docs/docsite/links.yml
@@ -9,6 +9,8 @@ edit_on_github:
   path_prefix: ''
 
 extra_links:
+  - description: Ask for help
+    url: https://forum.ansible.com/c/help/6/none
   - description: Submit a bug report
     url: https://github.com/ansible-collections/community.general/issues/new?assignees=&labels=&template=bug_report.yml
   - description: Request a feature

--- a/docs/docsite/links.yml
+++ b/docs/docsite/links.yml
@@ -26,6 +26,9 @@ communication:
     - topic: Ansible Project List
       url: https://groups.google.com/g/ansible-project
   forums:
-    - topic: Ansible Forum
+    - topic: "Ansible Forum: General usage and support questions"
       # The following URL directly points to the "Get Help" section
       url: https://forum.ansible.com/c/help/6/none
+    - topic: "Ansible Forum: Discussions about the collection itself, not for specific modules or plugins"
+      # The following URL directly points to the "community-general" tag
+      url: https://forum.ansible.com/tag/community-general

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@
 
 namespace: community
 name: general
-version: 9.3.0
+version: 9.4.0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/plugins/action/iptables_state.py
+++ b/plugins/action/iptables_state.py
@@ -88,6 +88,10 @@ class ActionModule(ActionBase):
             max_timeout = self._connection._play_context.timeout
             module_args = self._task.args
 
+            async_status_args = {}
+            starter_cmd = None
+            confirm_cmd = None
+
             if module_args.get('state', None) == 'restored':
                 if not wrap_async:
                     if not check_mode:

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -85,7 +85,6 @@ DOCUMENTATION = '''
             key: disable_attributes_in_logs
         version_added: 7.1.0
       store_spans_in_file:
-        default: None
         type: str
         description:
           -  It stores the exported spans in the given file

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -356,6 +356,7 @@ class OpenTelemetrySource(object):
         status = Status(status_code=StatusCode.OK)
         if host_data.status != 'included':
             # Support loops
+            enriched_error_message = None
             if 'results' in host_data.result._result:
                 if host_data.status == 'failed':
                     message = self.get_error_message_from_results(host_data.result._result['results'], task_data.action)

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -362,6 +362,34 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             except Exception:
                 return None
 
+    def _get_lxc_interfaces(self, properties, node, vmid):
+        status_key = self._fact('status')
+
+        if status_key not in properties or not properties[status_key] == 'running':
+            return
+
+        ret = self._get_json("%s/api2/json/nodes/%s/lxc/%s/interfaces" % (self.proxmox_url, node, vmid), ignore_errors=[501])
+        if not ret:
+            return
+
+        result = []
+
+        for iface in ret:
+            result_iface = {
+                'name': iface['name'],
+                'hwaddr': iface['hwaddr']
+            }
+
+            if 'inet' in iface:
+                result_iface['inet'] = iface['inet']
+
+            if 'inet6' in iface:
+                result_iface['inet6'] = iface['inet6']
+
+            result.append(result_iface)
+
+        properties[self._fact('lxc_interfaces')] = result
+
     def _get_agent_network_interfaces(self, node, vmid, vmtype):
         result = []
 
@@ -525,6 +553,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._get_vm_status(properties, node, vmid, ittype, name)
             self._get_vm_config(properties, node, vmid, ittype, name)
             self._get_vm_snapshots(properties, node, vmid, ittype, name)
+
+            if ittype == 'lxc':
+                self._get_lxc_interfaces(properties, node, vmid)
 
         # ensure the host satisfies filters
         if not self._can_add_host(name, properties):

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -469,7 +469,8 @@ class LookupModule(LookupBase):
     def opt_lock(self, type):
         if self.get_option('lock') == type:
             tmpdir = os.environ.get('TMPDIR', '/tmp')
-            lockfile = os.path.join(tmpdir, '.passwordstore.lock')
+            user = os.environ.get('USER')
+            lockfile = os.path.join(tmpdir, '.{0}.passwordstore.lock'.format(user))
             with FileLock().lock_file(lockfile, tmpdir, self.lock_timeout):
                 self.locked = type
                 yield

--- a/plugins/module_utils/ilo_redfish_utils.py
+++ b/plugins/module_utils/ilo_redfish_utils.py
@@ -29,6 +29,7 @@ class iLORedfishUtils(RedfishUtils):
         result['ret'] = True
         data = response['data']
 
+        current_session = None
         if 'Oem' in data:
             if data["Oem"]["Hpe"]["Links"]["MySession"]["@odata.id"]:
                 current_session = data["Oem"]["Hpe"]["Links"]["MySession"]["@odata.id"]

--- a/plugins/module_utils/pipx.py
+++ b/plugins/module_utils/pipx.py
@@ -28,7 +28,6 @@ def pipx_runner(module, command, **kwargs):
         module,
         command=command,
         arg_formats=dict(
-
             state=fmt.as_map(_state_map),
             name=fmt.as_list(),
             name_source=fmt.as_func(fmt.unpack_args(lambda n, s: [s] if s else [n])),
@@ -43,6 +42,7 @@ def pipx_runner(module, command, **kwargs):
             _list=fmt.as_fixed(['list', '--include-injected', '--json']),
             editable=fmt.as_bool("--editable"),
             pip_args=fmt.as_opt_eq_val('--pip-args'),
+            suffix=fmt.as_opt_val('--suffix'),
         ),
         environ_update={'USE_EMOJI': '0'},
         check_rc=True,

--- a/plugins/modules/aix_inittab.py
+++ b/plugins/modules/aix_inittab.py
@@ -192,6 +192,7 @@ def main():
     rmitab = module.get_bin_path('rmitab')
     chitab = module.get_bin_path('chitab')
     rc = 0
+    err = None
 
     # check if the new entry exists
     current_entry = check_current_entry(module)

--- a/plugins/modules/cronvar.py
+++ b/plugins/modules/cronvar.py
@@ -183,6 +183,7 @@ class CronVar(object):
             fileh = open(backup_file, 'w')
         elif self.cron_file:
             fileh = open(self.cron_file, 'w')
+            path = None
         else:
             filed, path = tempfile.mkstemp(prefix='crontab')
             fileh = os.fdopen(filed, 'w')

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -34,160 +34,17 @@ attributes:
     support: none
 
 options:
-  group:
-    description:
-      - Id or the full path of the group of which this projects belongs to.
-    type: str
-  name:
-    description:
-      - The name of the project.
-    required: true
-    type: str
-  path:
-    description:
-      - The path of the project you want to create, this will be server_url/<group>/path.
-      - If not supplied, name will be used.
-    type: str
-  description:
-    description:
-      - An description for the project.
-    type: str
-  initialize_with_readme:
-    description:
-      - Will initialize the project with a default C(README.md).
-      - Is only used when the project is created, and ignored otherwise.
-    type: bool
-    default: false
-    version_added: "4.0.0"
-  issues_enabled:
-    description:
-      - Whether you want to create issues or not.
-      - Possible values are true and false.
-    type: bool
-    default: true
-  merge_requests_enabled:
-    description:
-      - If merge requests can be made or not.
-      - Possible values are true and false.
-    type: bool
-    default: true
-  wiki_enabled:
-    description:
-      - If an wiki for this project should be available or not.
-    type: bool
-    default: true
-  snippets_enabled:
-    description:
-      - If creating snippets should be available or not.
-    type: bool
-    default: true
-  visibility:
-    description:
-      - V(private) Project access must be granted explicitly for each user.
-      - V(internal) The project can be cloned by any logged in user.
-      - V(public) The project can be cloned without any authentication.
-    default: private
-    type: str
-    choices: ["private", "internal", "public"]
-    aliases:
-      - visibility_level
-  import_url:
-    description:
-      - Git repository which will be imported into gitlab.
-      - GitLab server needs read access to this git repository.
-    required: false
-    type: str
-  state:
-    description:
-      - Create or delete project.
-      - Possible values are present and absent.
-    default: present
-    type: str
-    choices: ["present", "absent"]
-  merge_method:
-    description:
-      - What requirements are placed upon merges.
-      - Possible values are V(merge), V(rebase_merge) merge commit with semi-linear history, V(ff) fast-forward merges only.
-    type: str
-    choices: ["ff", "merge", "rebase_merge"]
-    default: merge
-    version_added: "1.0.0"
-  lfs_enabled:
-    description:
-      - Enable Git large file systems to manages large files such
-        as audio, video, and graphics files.
-    type: bool
-    required: false
-    default: false
-    version_added: "2.0.0"
-  username:
-    description:
-      - Used to create a personal project under a user's name.
-    type: str
-    version_added: "3.3.0"
   allow_merge_on_skipped_pipeline:
     description:
       - Allow merge when skipped pipelines exist.
     type: bool
     version_added: "3.4.0"
-  only_allow_merge_if_all_discussions_are_resolved:
-    description:
-      - All discussions on a merge request (MR) have to be resolved.
-    type: bool
-    version_added: "3.4.0"
-  only_allow_merge_if_pipeline_succeeds:
-    description:
-      - Only allow merges if pipeline succeeded.
-    type: bool
-    version_added: "3.4.0"
-  packages_enabled:
-    description:
-      - Enable GitLab package repository.
-    type: bool
-    version_added: "3.4.0"
-  remove_source_branch_after_merge:
-    description:
-      - Remove the source branch after merge.
-    type: bool
-    version_added: "3.4.0"
-  squash_option:
-    description:
-      - Squash commits when merging.
-    type: str
-    choices: ["never", "always", "default_off", "default_on"]
-    version_added: "3.4.0"
-  ci_config_path:
-    description:
-      - Custom path to the CI configuration file for this project.
-    type: str
-    version_added: "3.7.0"
-  shared_runners_enabled:
-    description:
-      - Enable shared runners for this project.
-    type: bool
-    version_added: "3.7.0"
   avatar_path:
     description:
       - Absolute path image to configure avatar. File size should not exceed 200 kb.
       - This option is only used on creation, not for updates.
     type: path
     version_added: "4.2.0"
-  default_branch:
-    description:
-      - The default branch name for this project.
-      - For project creation, this option requires O(initialize_with_readme=true).
-      - For project update, the branch must exist.
-      - Supports project's default branch update since community.general 8.0.0.
-    type: str
-    version_added: "4.2.0"
-  repository_access_level:
-    description:
-      - V(private) means that accessing repository is allowed only to project members.
-      - V(disabled) means that accessing repository is disabled.
-      - V(enabled) means that accessing repository is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "9.3.0"
   builds_access_level:
     description:
       - V(private) means that repository CI/CD is allowed only to project members.
@@ -196,77 +53,11 @@ options:
     type: str
     choices: ["private", "disabled", "enabled"]
     version_added: "6.2.0"
-  forking_access_level:
+  ci_config_path:
     description:
-      - V(private) means that repository forks is allowed only to project members.
-      - V(disabled) means that repository forks are disabled.
-      - V(enabled) means that repository forks are enabled.
+      - Custom path to the CI configuration file for this project.
     type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.2.0"
-  container_registry_access_level:
-    description:
-      - V(private) means that container registry is allowed only to project members.
-      - V(disabled) means that container registry is disabled.
-      - V(enabled) means that container registry is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.2.0"
-  releases_access_level:
-    description:
-      - V(private) means that accessing release is allowed only to project members.
-      - V(disabled) means that accessing release is disabled.
-      - V(enabled) means that accessing release is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  environments_access_level:
-    description:
-      - V(private) means that deployment to environment is allowed only to project members.
-      - V(disabled) means that deployment to environment is disabled.
-      - V(enabled) means that deployment to environment is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  feature_flags_access_level:
-    description:
-      - V(private) means that feature rollout is allowed only to project members.
-      - V(disabled) means that feature rollout is disabled.
-      - V(enabled) means that feature rollout is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  infrastructure_access_level:
-    description:
-      - V(private) means that configuring infrastructure is allowed only to project members.
-      - V(disabled) means that configuring infrastructure is disabled.
-      - V(enabled) means that configuring infrastructure is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  monitor_access_level:
-    description:
-      - V(private) means that monitoring health is allowed only to project members.
-      - V(disabled) means that monitoring health is disabled.
-      - V(enabled) means that monitoring health is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  security_and_compliance_access_level:
-    description:
-      - V(private) means that accessing security and complicance tab is allowed only to project members.
-      - V(disabled) means that accessing security and complicance tab is disabled.
-      - V(enabled) means that accessing security and complicance tab is enabled.
-    type: str
-    choices: ["private", "disabled", "enabled"]
-    version_added: "6.4.0"
-  topics:
-    description:
-      - A topic or list of topics to be assigned to a project.
-      - It is compatible with old GitLab server releases (versions before 14, correspond to C(tag_list)).
-    type: list
-    elements: str
-    version_added: "6.6.0"
+    version_added: "3.7.0"
   container_expiration_policy:
     description:
       - Project cleanup policy for its container registry.
@@ -302,19 +93,103 @@ options:
           - Keep tags matching this regular expression.
         type: str
     version_added: "9.3.0"
-  pages_access_level:
+  container_registry_access_level:
     description:
-      - V(private) means that accessing pages tab is allowed only to project members.
-      - V(disabled) means that accessing pages tab is disabled.
-      - V(enabled) means that accessing pages tab is enabled.
+      - V(private) means that container registry is allowed only to project members.
+      - V(disabled) means that container registry is disabled.
+      - V(enabled) means that container registry is enabled.
     type: str
     choices: ["private", "disabled", "enabled"]
-    version_added: "9.3.0"
-  service_desk_enabled:
+    version_added: "6.2.0"
+  default_branch:
     description:
-      - Enable Service Desk.
+      - The default branch name for this project.
+      - For project creation, this option requires O(initialize_with_readme=true).
+      - For project update, the branch must exist.
+      - Supports project's default branch update since community.general 8.0.0.
+    type: str
+    version_added: "4.2.0"
+  description:
+    description:
+      - An description for the project.
+    type: str
+  environments_access_level:
+    description:
+      - V(private) means that deployment to environment is allowed only to project members.
+      - V(disabled) means that deployment to environment is disabled.
+      - V(enabled) means that deployment to environment is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  feature_flags_access_level:
+    description:
+      - V(private) means that feature rollout is allowed only to project members.
+      - V(disabled) means that feature rollout is disabled.
+      - V(enabled) means that feature rollout is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  forking_access_level:
+    description:
+      - V(private) means that repository forks is allowed only to project members.
+      - V(disabled) means that repository forks are disabled.
+      - V(enabled) means that repository forks are enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.2.0"
+  group:
+    description:
+      - Id or the full path of the group of which this projects belongs to.
+    type: str
+  import_url:
+    description:
+      - Git repository which will be imported into gitlab.
+      - GitLab server needs read access to this git repository.
+    required: false
+    type: str
+  infrastructure_access_level:
+    description:
+      - V(private) means that configuring infrastructure is allowed only to project members.
+      - V(disabled) means that configuring infrastructure is disabled.
+      - V(enabled) means that configuring infrastructure is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  initialize_with_readme:
+    description:
+      - Will initialize the project with a default C(README.md).
+      - Is only used when the project is created, and ignored otherwise.
     type: bool
-    version_added: "9.3.0"
+    default: false
+    version_added: "4.0.0"
+  issues_enabled:
+    description:
+      - Whether you want to create issues or not.
+      - Possible values are true and false.
+    type: bool
+    default: true
+  lfs_enabled:
+    description:
+      - Enable Git large file systems to manages large files such
+        as audio, video, and graphics files.
+    type: bool
+    required: false
+    default: false
+    version_added: "2.0.0"
+  merge_method:
+    description:
+      - What requirements are placed upon merges.
+      - Possible values are V(merge), V(rebase_merge) merge commit with semi-linear history, V(ff) fast-forward merges only.
+    type: str
+    choices: ["ff", "merge", "rebase_merge"]
+    default: merge
+    version_added: "1.0.0"
+  merge_requests_enabled:
+    description:
+      - If merge requests can be made or not.
+      - Possible values are true and false.
+    type: bool
+    default: true
   model_registry_access_level:
     description:
       - V(private) means that accessing model registry tab is allowed only to project members.
@@ -323,6 +198,131 @@ options:
     type: str
     choices: ["private", "disabled", "enabled"]
     version_added: "9.3.0"
+  monitor_access_level:
+    description:
+      - V(private) means that monitoring health is allowed only to project members.
+      - V(disabled) means that monitoring health is disabled.
+      - V(enabled) means that monitoring health is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  name:
+    description:
+      - The name of the project.
+    required: true
+    type: str
+  only_allow_merge_if_all_discussions_are_resolved:
+    description:
+      - All discussions on a merge request (MR) have to be resolved.
+    type: bool
+    version_added: "3.4.0"
+  only_allow_merge_if_pipeline_succeeds:
+    description:
+      - Only allow merges if pipeline succeeded.
+    type: bool
+    version_added: "3.4.0"
+  packages_enabled:
+    description:
+      - Enable GitLab package repository.
+    type: bool
+    version_added: "3.4.0"
+  pages_access_level:
+    description:
+      - V(private) means that accessing pages tab is allowed only to project members.
+      - V(disabled) means that accessing pages tab is disabled.
+      - V(enabled) means that accessing pages tab is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "9.3.0"
+  path:
+    description:
+      - The path of the project you want to create, this will be server_url/<group>/path.
+      - If not supplied, name will be used.
+    type: str
+  releases_access_level:
+    description:
+      - V(private) means that accessing release is allowed only to project members.
+      - V(disabled) means that accessing release is disabled.
+      - V(enabled) means that accessing release is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  remove_source_branch_after_merge:
+    description:
+      - Remove the source branch after merge.
+    type: bool
+    version_added: "3.4.0"
+  repository_access_level:
+    description:
+      - V(private) means that accessing repository is allowed only to project members.
+      - V(disabled) means that accessing repository is disabled.
+      - V(enabled) means that accessing repository is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "9.3.0"
+  security_and_compliance_access_level:
+    description:
+      - V(private) means that accessing security and complicance tab is allowed only to project members.
+      - V(disabled) means that accessing security and complicance tab is disabled.
+      - V(enabled) means that accessing security and complicance tab is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  service_desk_enabled:
+    description:
+      - Enable Service Desk.
+    type: bool
+    version_added: "9.3.0"
+  shared_runners_enabled:
+    description:
+      - Enable shared runners for this project.
+    type: bool
+    version_added: "3.7.0"
+  snippets_enabled:
+    description:
+      - If creating snippets should be available or not.
+    type: bool
+    default: true
+  squash_option:
+    description:
+      - Squash commits when merging.
+    type: str
+    choices: ["never", "always", "default_off", "default_on"]
+    version_added: "3.4.0"
+  state:
+    description:
+      - Create or delete project.
+      - Possible values are present and absent.
+    default: present
+    type: str
+    choices: ["present", "absent"]
+  topics:
+    description:
+      - A topic or list of topics to be assigned to a project.
+      - It is compatible with old GitLab server releases (versions before 14, correspond to C(tag_list)).
+    type: list
+    elements: str
+    version_added: "6.6.0"
+  username:
+    description:
+      - Used to create a personal project under a user's name.
+    type: str
+    version_added: "3.3.0"
+  visibility:
+    description:
+      - V(private) Project access must be granted explicitly for each user.
+      - V(internal) The project can be cloned by any logged in user.
+      - V(public) The project can be cloned without any authentication.
+    default: private
+    type: str
+    choices: ["private", "internal", "public"]
+    aliases:
+      - visibility_level
+  wiki_enabled:
+    description:
+      - If an wiki for this project should be available or not.
+    type: bool
+    default: true
 '''
 
 EXAMPLES = r'''
@@ -422,37 +422,37 @@ class GitLabProject(object):
     def create_or_update_project(self, module, project_name, namespace, options):
         changed = False
         project_options = {
-            'name': project_name,
-            'description': options['description'],
-            'issues_enabled': options['issues_enabled'],
-            'merge_requests_enabled': options['merge_requests_enabled'],
-            'merge_method': options['merge_method'],
-            'wiki_enabled': options['wiki_enabled'],
-            'snippets_enabled': options['snippets_enabled'],
-            'visibility': options['visibility'],
-            'lfs_enabled': options['lfs_enabled'],
             'allow_merge_on_skipped_pipeline': options['allow_merge_on_skipped_pipeline'],
+            'builds_access_level': options['builds_access_level'],
+            'ci_config_path': options['ci_config_path'],
+            'container_expiration_policy': options['container_expiration_policy'],
+            'container_registry_access_level': options['container_registry_access_level'],
+            'description': options['description'],
+            'environments_access_level': options['environments_access_level'],
+            'feature_flags_access_level': options['feature_flags_access_level'],
+            'forking_access_level': options['forking_access_level'],
+            'infrastructure_access_level': options['infrastructure_access_level'],
+            'issues_enabled': options['issues_enabled'],
+            'lfs_enabled': options['lfs_enabled'],
+            'merge_method': options['merge_method'],
+            'merge_requests_enabled': options['merge_requests_enabled'],
+            'model_registry_access_level': options['model_registry_access_level'],
+            'monitor_access_level': options['monitor_access_level'],
+            'name': project_name,
             'only_allow_merge_if_all_discussions_are_resolved': options['only_allow_merge_if_all_discussions_are_resolved'],
             'only_allow_merge_if_pipeline_succeeds': options['only_allow_merge_if_pipeline_succeeds'],
             'packages_enabled': options['packages_enabled'],
-            'remove_source_branch_after_merge': options['remove_source_branch_after_merge'],
-            'squash_option': options['squash_option'],
-            'ci_config_path': options['ci_config_path'],
-            'shared_runners_enabled': options['shared_runners_enabled'],
-            'repository_access_level': options['repository_access_level'],
-            'builds_access_level': options['builds_access_level'],
-            'forking_access_level': options['forking_access_level'],
-            'container_registry_access_level': options['container_registry_access_level'],
-            'releases_access_level': options['releases_access_level'],
-            'environments_access_level': options['environments_access_level'],
-            'feature_flags_access_level': options['feature_flags_access_level'],
-            'infrastructure_access_level': options['infrastructure_access_level'],
-            'monitor_access_level': options['monitor_access_level'],
-            'security_and_compliance_access_level': options['security_and_compliance_access_level'],
-            'container_expiration_policy': options['container_expiration_policy'],
             'pages_access_level': options['pages_access_level'],
+            'releases_access_level': options['releases_access_level'],
+            'remove_source_branch_after_merge': options['remove_source_branch_after_merge'],
+            'repository_access_level': options['repository_access_level'],
+            'security_and_compliance_access_level': options['security_and_compliance_access_level'],
             'service_desk_enabled': options['service_desk_enabled'],
-            'model_registry_access_level': options['model_registry_access_level'],
+            'shared_runners_enabled': options['shared_runners_enabled'],
+            'snippets_enabled': options['snippets_enabled'],
+            'squash_option': options['squash_option'],
+            'visibility': options['visibility'],
+            'wiki_enabled': options['wiki_enabled'],
         }
 
         # topics was introduced on gitlab >=14 and replace tag_list. We get current gitlab version
@@ -465,7 +465,7 @@ class GitLabProject(object):
         # Because we have already call userExists in main()
         if self.project_object is None:
             if options['default_branch'] and not options['initialize_with_readme']:
-                module.fail_json(msg="Param default_branch need param initialize_with_readme set to true")
+                module.fail_json(msg="Param default_branch needs param initialize_with_readme set to true")
             project_options.update({
                 'path': options['path'],
                 'import_url': options['import_url'],
@@ -499,7 +499,7 @@ class GitLabProject(object):
             try:
                 project.save()
             except Exception as e:
-                self._module.fail_json(msg="Failed update project: %s " % e)
+                self._module.fail_json(msg="Failed to update project: %s " % e)
             return True
         return False
 
@@ -583,42 +583,10 @@ def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(auth_argument_spec())
     argument_spec.update(dict(
-        group=dict(type='str'),
-        name=dict(type='str', required=True),
-        path=dict(type='str'),
-        description=dict(type='str'),
-        initialize_with_readme=dict(type='bool', default=False),
-        default_branch=dict(type='str'),
-        issues_enabled=dict(type='bool', default=True),
-        merge_requests_enabled=dict(type='bool', default=True),
-        merge_method=dict(type='str', default='merge', choices=["merge", "rebase_merge", "ff"]),
-        wiki_enabled=dict(type='bool', default=True),
-        snippets_enabled=dict(default=True, type='bool'),
-        visibility=dict(type='str', default="private", choices=["internal", "private", "public"], aliases=["visibility_level"]),
-        import_url=dict(type='str'),
-        state=dict(type='str', default="present", choices=["absent", "present"]),
-        lfs_enabled=dict(default=False, type='bool'),
-        username=dict(type='str'),
         allow_merge_on_skipped_pipeline=dict(type='bool'),
-        only_allow_merge_if_all_discussions_are_resolved=dict(type='bool'),
-        only_allow_merge_if_pipeline_succeeds=dict(type='bool'),
-        packages_enabled=dict(type='bool'),
-        remove_source_branch_after_merge=dict(type='bool'),
-        squash_option=dict(type='str', choices=['never', 'always', 'default_off', 'default_on']),
-        ci_config_path=dict(type='str'),
-        shared_runners_enabled=dict(type='bool'),
         avatar_path=dict(type='path'),
-        repository_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
         builds_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        forking_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        container_registry_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        releases_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        environments_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        feature_flags_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        infrastructure_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        monitor_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        security_and_compliance_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        topics=dict(type='list', elements='str'),
+        ci_config_path=dict(type='str'),
         container_expiration_policy=dict(type='dict', default=None, options=dict(
             cadence=dict(type='str', choices=["1d", "7d", "14d", "1month", "3month"]),
             enabled=dict(type='bool'),
@@ -627,9 +595,41 @@ def main():
             name_regex=dict(type='str'),
             name_regex_keep=dict(type='str'),
         )),
-        pages_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        service_desk_enabled=dict(type='bool'),
+        container_registry_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        default_branch=dict(type='str'),
+        description=dict(type='str'),
+        environments_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        feature_flags_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        forking_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        group=dict(type='str'),
+        import_url=dict(type='str'),
+        infrastructure_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        initialize_with_readme=dict(type='bool', default=False),
+        issues_enabled=dict(type='bool', default=True),
+        lfs_enabled=dict(default=False, type='bool'),
+        merge_method=dict(type='str', default='merge', choices=["merge", "rebase_merge", "ff"]),
+        merge_requests_enabled=dict(type='bool', default=True),
         model_registry_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        monitor_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        name=dict(type='str', required=True),
+        only_allow_merge_if_all_discussions_are_resolved=dict(type='bool'),
+        only_allow_merge_if_pipeline_succeeds=dict(type='bool'),
+        packages_enabled=dict(type='bool'),
+        pages_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        path=dict(type='str'),
+        releases_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        remove_source_branch_after_merge=dict(type='bool'),
+        repository_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        security_and_compliance_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        service_desk_enabled=dict(type='bool'),
+        shared_runners_enabled=dict(type='bool'),
+        snippets_enabled=dict(default=True, type='bool'),
+        squash_option=dict(type='str', choices=['never', 'always', 'default_off', 'default_on']),
+        state=dict(type='str', default="present", choices=["absent", "present"]),
+        topics=dict(type='list', elements='str'),
+        username=dict(type='str'),
+        visibility=dict(type='str', default="private", choices=["internal", "private", "public"], aliases=["visibility_level"]),
+        wiki_enabled=dict(type='bool', default=True),
     ))
 
     module = AnsibleModule(
@@ -654,46 +654,46 @@ def main():
     # check prerequisites and connect to gitlab server
     gitlab_instance = gitlab_authentication(module)
 
+    allow_merge_on_skipped_pipeline = module.params['allow_merge_on_skipped_pipeline']
+    avatar_path = module.params['avatar_path']
+    builds_access_level = module.params['builds_access_level']
+    ci_config_path = module.params['ci_config_path']
+    container_expiration_policy = module.params['container_expiration_policy']
+    container_registry_access_level = module.params['container_registry_access_level']
+    default_branch = module.params['default_branch']
+    environments_access_level = module.params['environments_access_level']
+    feature_flags_access_level = module.params['feature_flags_access_level']
+    forking_access_level = module.params['forking_access_level']
     group_identifier = module.params['group']
-    project_name = module.params['name']
-    project_path = module.params['path']
-    project_description = module.params['description']
+    import_url = module.params['import_url']
+    infrastructure_access_level = module.params['infrastructure_access_level']
     initialize_with_readme = module.params['initialize_with_readme']
     issues_enabled = module.params['issues_enabled']
-    merge_requests_enabled = module.params['merge_requests_enabled']
-    merge_method = module.params['merge_method']
-    wiki_enabled = module.params['wiki_enabled']
-    snippets_enabled = module.params['snippets_enabled']
-    visibility = module.params['visibility']
-    import_url = module.params['import_url']
-    state = module.params['state']
     lfs_enabled = module.params['lfs_enabled']
-    username = module.params['username']
-    allow_merge_on_skipped_pipeline = module.params['allow_merge_on_skipped_pipeline']
+    merge_method = module.params['merge_method']
+    merge_requests_enabled = module.params['merge_requests_enabled']
+    model_registry_access_level = module.params['model_registry_access_level']
+    monitor_access_level = module.params['monitor_access_level']
     only_allow_merge_if_all_discussions_are_resolved = module.params['only_allow_merge_if_all_discussions_are_resolved']
     only_allow_merge_if_pipeline_succeeds = module.params['only_allow_merge_if_pipeline_succeeds']
     packages_enabled = module.params['packages_enabled']
-    remove_source_branch_after_merge = module.params['remove_source_branch_after_merge']
-    squash_option = module.params['squash_option']
-    ci_config_path = module.params['ci_config_path']
-    shared_runners_enabled = module.params['shared_runners_enabled']
-    avatar_path = module.params['avatar_path']
-    default_branch = module.params['default_branch']
-    repository_access_level = module.params['repository_access_level']
-    builds_access_level = module.params['builds_access_level']
-    forking_access_level = module.params['forking_access_level']
-    container_registry_access_level = module.params['container_registry_access_level']
-    releases_access_level = module.params['releases_access_level']
-    environments_access_level = module.params['environments_access_level']
-    feature_flags_access_level = module.params['feature_flags_access_level']
-    infrastructure_access_level = module.params['infrastructure_access_level']
-    monitor_access_level = module.params['monitor_access_level']
-    security_and_compliance_access_level = module.params['security_and_compliance_access_level']
-    topics = module.params['topics']
-    container_expiration_policy = module.params['container_expiration_policy']
     pages_access_level = module.params['pages_access_level']
+    project_description = module.params['description']
+    project_name = module.params['name']
+    project_path = module.params['path']
+    releases_access_level = module.params['releases_access_level']
+    remove_source_branch_after_merge = module.params['remove_source_branch_after_merge']
+    repository_access_level = module.params['repository_access_level']
+    security_and_compliance_access_level = module.params['security_and_compliance_access_level']
     service_desk_enabled = module.params['service_desk_enabled']
-    model_registry_access_level = module.params['model_registry_access_level']
+    shared_runners_enabled = module.params['shared_runners_enabled']
+    snippets_enabled = module.params['snippets_enabled']
+    squash_option = module.params['squash_option']
+    state = module.params['state']
+    topics = module.params['topics']
+    username = module.params['username']
+    visibility = module.params['visibility']
+    wiki_enabled = module.params['wiki_enabled']
 
     # Set project_path to project_name if it is empty.
     if project_path is None:
@@ -737,42 +737,42 @@ def main():
     if state == 'present':
 
         if gitlab_project.create_or_update_project(module, project_name, namespace, {
-            "path": project_path,
-            "description": project_description,
-            "initialize_with_readme": initialize_with_readme,
-            "default_branch": default_branch,
-            "issues_enabled": issues_enabled,
-            "merge_requests_enabled": merge_requests_enabled,
-            "merge_method": merge_method,
-            "wiki_enabled": wiki_enabled,
-            "snippets_enabled": snippets_enabled,
-            "visibility": visibility,
-            "import_url": import_url,
-            "lfs_enabled": lfs_enabled,
             "allow_merge_on_skipped_pipeline": allow_merge_on_skipped_pipeline,
+            "avatar_path": avatar_path,
+            "builds_access_level": builds_access_level,
+            "ci_config_path": ci_config_path,
+            "container_expiration_policy": container_expiration_policy,
+            "container_registry_access_level": container_registry_access_level,
+            "default_branch": default_branch,
+            "description": project_description,
+            "environments_access_level": environments_access_level,
+            "feature_flags_access_level": feature_flags_access_level,
+            "forking_access_level": forking_access_level,
+            "import_url": import_url,
+            "infrastructure_access_level": infrastructure_access_level,
+            "initialize_with_readme": initialize_with_readme,
+            "issues_enabled": issues_enabled,
+            "lfs_enabled": lfs_enabled,
+            "merge_method": merge_method,
+            "merge_requests_enabled": merge_requests_enabled,
+            "model_registry_access_level": model_registry_access_level,
+            "monitor_access_level": monitor_access_level,
             "only_allow_merge_if_all_discussions_are_resolved": only_allow_merge_if_all_discussions_are_resolved,
             "only_allow_merge_if_pipeline_succeeds": only_allow_merge_if_pipeline_succeeds,
             "packages_enabled": packages_enabled,
-            "remove_source_branch_after_merge": remove_source_branch_after_merge,
-            "squash_option": squash_option,
-            "ci_config_path": ci_config_path,
-            "shared_runners_enabled": shared_runners_enabled,
-            "avatar_path": avatar_path,
-            "repository_access_level": repository_access_level,
-            "builds_access_level": builds_access_level,
-            "forking_access_level": forking_access_level,
-            "container_registry_access_level": container_registry_access_level,
-            "releases_access_level": releases_access_level,
-            "environments_access_level": environments_access_level,
-            "feature_flags_access_level": feature_flags_access_level,
-            "infrastructure_access_level": infrastructure_access_level,
-            "monitor_access_level": monitor_access_level,
-            "security_and_compliance_access_level": security_and_compliance_access_level,
-            "topics": topics,
-            "container_expiration_policy": container_expiration_policy,
             "pages_access_level": pages_access_level,
+            "path": project_path,
+            "releases_access_level": releases_access_level,
+            "remove_source_branch_after_merge": remove_source_branch_after_merge,
+            "repository_access_level": repository_access_level,
+            "security_and_compliance_access_level": security_and_compliance_access_level,
             "service_desk_enabled": service_desk_enabled,
-            "model_registry_access_level": model_registry_access_level,
+            "shared_runners_enabled": shared_runners_enabled,
+            "snippets_enabled": snippets_enabled,
+            "squash_option": squash_option,
+            "topics": topics,
+            "visibility": visibility,
+            "wiki_enabled": wiki_enabled,
         }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.project_object._attrs)

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -302,6 +302,27 @@ options:
           - Keep tags matching this regular expression.
         type: str
     version_added: "9.3.0"
+  pages_access_level:
+    description:
+      - V(private) means that accessing pages tab is allowed only to project members.
+      - V(disabled) means that accessing pages tab is disabled.
+      - V(enabled) means that accessing pages tab is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "9.3.0"
+  service_desk_enabled:
+    description:
+      - Enable Service Desk.
+    type: bool
+    version_added: "9.3.0"
+  model_registry_access_level:
+    description:
+      - V(private) means that accessing model registry tab is allowed only to project members.
+      - V(disabled) means that accessing model registry tab is disabled.
+      - V(enabled) means that accessing model registry tab is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "9.3.0"
 '''
 
 EXAMPLES = r'''
@@ -429,6 +450,9 @@ class GitLabProject(object):
             'monitor_access_level': options['monitor_access_level'],
             'security_and_compliance_access_level': options['security_and_compliance_access_level'],
             'container_expiration_policy': options['container_expiration_policy'],
+            'pages_access_level': options['pages_access_level'],
+            'service_desk_enabled': options['service_desk_enabled'],
+            'model_registry_access_level': options['model_registry_access_level'],
         }
 
         # topics was introduced on gitlab >=14 and replace tag_list. We get current gitlab version
@@ -603,6 +627,9 @@ def main():
             name_regex=dict(type='str'),
             name_regex_keep=dict(type='str'),
         )),
+        pages_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        service_desk_enabled=dict(type='bool'),
+        model_registry_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
     ))
 
     module = AnsibleModule(
@@ -664,6 +691,9 @@ def main():
     security_and_compliance_access_level = module.params['security_and_compliance_access_level']
     topics = module.params['topics']
     container_expiration_policy = module.params['container_expiration_policy']
+    pages_access_level = module.params['pages_access_level']
+    service_desk_enabled = module.params['service_desk_enabled']
+    model_registry_access_level = module.params['model_registry_access_level']
 
     # Set project_path to project_name if it is empty.
     if project_path is None:
@@ -702,7 +732,7 @@ def main():
         if project_exists:
             gitlab_project.delete_project()
             module.exit_json(changed=True, msg="Successfully deleted project %s" % project_name)
-        module.exit_json(changed=False, msg="Project deleted or does not exists")
+        module.exit_json(changed=False, msg="Project deleted or does not exist")
 
     if state == 'present':
 
@@ -740,6 +770,9 @@ def main():
             "security_and_compliance_access_level": security_and_compliance_access_level,
             "topics": topics,
             "container_expiration_policy": container_expiration_policy,
+            "pages_access_level": pages_access_level,
+            "service_desk_enabled": service_desk_enabled,
+            "model_registry_access_level": model_registry_access_level,
         }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.project_object._attrs)

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -534,7 +534,12 @@ class HomebrewCask(object):
             rc, out, err = self.module.run_command(cmd)
 
         if rc == 0:
-            if re.search(r'==> No Casks to upgrade', out.strip(), re.IGNORECASE):
+            # 'brew upgrade --cask' does not output anything if no casks are upgraded
+            if not out.strip():
+                self.message = 'Homebrew casks already upgraded.'
+
+            # handle legacy 'brew cask upgrade'
+            elif re.search(r'==> No Casks to upgrade', out.strip(), re.IGNORECASE):
                 self.message = 'Homebrew casks already upgraded.'
 
             else:

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -459,6 +459,7 @@ def main():
         if not os.access(b_path, os.R_OK):
             module.fail_json(msg="Source %s not readable" % path)
         state_to_restore = read_state(b_path)
+        cmd = None
     else:
         cmd = ' '.join(SAVECOMMAND)
 

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -892,11 +892,11 @@ def main():
             if cid is None:
                 old_mapper = {}
             elif change.get('id') is not None:
-                old_mapper = kc.get_component(change['id'], realm)
+                old_mapper = next((before_mapper for before_mapper in before_mapper.get('mappers', []) if before_mapper["id"] == change['id']), None)
                 if old_mapper is None:
                     old_mapper = {}
             else:
-                found = kc.get_components(urlencode(dict(parent=cid, name=change['name'])), realm)
+                found = [before_mapper for before_mapper in before_comp.get('mappers', []) if before_mapper['name'] == change['name']]
                 if len(found) > 1:
                     module.fail_json(msg='Found multiple mappers with name `{name}`. Cannot continue.'.format(name=change['name']))
                 if len(found) == 1:
@@ -905,10 +905,10 @@ def main():
                     old_mapper = {}
             new_mapper = old_mapper.copy()
             new_mapper.update(change)
-            if new_mapper != old_mapper:
-                if changeset.get('mappers') is None:
-                    changeset['mappers'] = list()
-                changeset['mappers'].append(new_mapper)
+            # changeset contains all desired mappers: those existing, to update or to create
+            if changeset.get('mappers') is None:
+                changeset['mappers'] = list()
+            changeset['mappers'].append(new_mapper)
 
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)
     desired_comp = before_comp.copy()
@@ -931,42 +931,51 @@ def main():
         # Process a creation
         result['changed'] = True
 
-        if module._diff:
-            result['diff'] = dict(before='', after=sanitize(desired_comp))
-
         if module.check_mode:
+            if module._diff:
+                result['diff'] = dict(before='', after=sanitize(desired_comp))
             module.exit_json(**result)
 
         # create it
-        desired_comp = desired_comp.copy()
-        updated_mappers = desired_comp.pop('mappers', [])
+        desired_mappers = desired_comp.pop('mappers', [])
         after_comp = kc.create_component(desired_comp, realm)
-
         cid = after_comp['id']
+        updated_mappers = []
+        # when creating a user federation, keycloak automatically creates default mappers
+        default_mappers = kc.get_components(urlencode(dict(parent=cid)), realm)
 
-        for mapper in updated_mappers:
-            found = kc.get_components(urlencode(dict(parent=cid, name=mapper['name'])), realm)
+        # create new mappers or update existing default mappers
+        for desired_mapper in desired_mappers:
+            found = [default_mapper for default_mapper in default_mappers if default_mapper['name'] == desired_mapper['name']]
             if len(found) > 1:
-                module.fail_json(msg='Found multiple mappers with name `{name}`. Cannot continue.'.format(name=mapper['name']))
+                module.fail_json(msg='Found multiple mappers with name `{name}`. Cannot continue.'.format(name=desired_mapper['name']))
             if len(found) == 1:
                 old_mapper = found[0]
             else:
                 old_mapper = {}
 
             new_mapper = old_mapper.copy()
-            new_mapper.update(mapper)
+            new_mapper.update(desired_mapper)
 
             if new_mapper.get('id') is not None:
                 kc.update_component(new_mapper, realm)
+                updated_mappers.append(new_mapper)
             else:
                 if new_mapper.get('parentId') is None:
-                    new_mapper['parentId'] = after_comp['id']
-                mapper = kc.create_component(new_mapper, realm)
+                    new_mapper['parentId'] = cid
+                updated_mappers.append(kc.create_component(new_mapper, realm))
 
-        after_comp['mappers'] = updated_mappers
+        # we remove all unwanted default mappers
+        # we use ids so we dont accidently remove one of the previously updated default mapper
+        for default_mapper in default_mappers:
+            if not default_mapper['id'] in [x['id'] for x in updated_mappers]:
+                kc.delete_component(default_mapper['id'], realm)
+
+        after_comp['mappers'] = kc.get_components(urlencode(dict(parent=cid)), realm)
+        if module._diff:
+            result['diff'] = dict(before='', after=sanitize(after_comp))
         result['end_state'] = sanitize(after_comp)
-
-        result['msg'] = "User federation {id} has been created".format(id=after_comp['id'])
+        result['msg'] = "User federation {id} has been created".format(id=cid)
         module.exit_json(**result)
 
     else:
@@ -990,22 +999,32 @@ def main():
                 module.exit_json(**result)
 
             # do the update
-            desired_comp = desired_comp.copy()
-            updated_mappers = desired_comp.pop('mappers', [])
+            desired_mappers = desired_comp.pop('mappers', [])
             kc.update_component(desired_comp, realm)
-            after_comp = kc.get_component(cid, realm)
 
-            for mapper in updated_mappers:
+            for before_mapper in before_comp.get('mappers', []):
+                # remove unwanted existing mappers that will not be updated
+                if not before_mapper['id'] in [x['id'] for x in desired_mappers]:
+                    kc.delete_component(before_mapper['id'], realm)
+
+            for mapper in desired_mappers:
+                if mapper in before_comp.get('mappers', []):
+                    continue
                 if mapper.get('id') is not None:
                     kc.update_component(mapper, realm)
                 else:
                     if mapper.get('parentId') is None:
                         mapper['parentId'] = desired_comp['id']
-                    mapper = kc.create_component(mapper, realm)
+                    kc.create_component(mapper, realm)
 
-            after_comp['mappers'] = updated_mappers
-            result['end_state'] = sanitize(after_comp)
-
+            after_comp = kc.get_component(cid, realm)
+            after_comp['mappers'] = kc.get_components(urlencode(dict(parent=cid)), realm)
+            after_comp_sanitized = sanitize(after_comp)
+            before_comp_sanitized = sanitize(before_comp)
+            result['end_state'] = after_comp_sanitized
+            if module._diff:
+                result['diff'] = dict(before=before_comp_sanitized, after=after_comp_sanitized)
+            result['changed'] = before_comp_sanitized != after_comp_sanitized
             result['msg'] = "User federation {id} has been updated".format(id=cid)
             module.exit_json(**result)
 

--- a/plugins/modules/memset_zone_record.py
+++ b/plugins/modules/memset_zone_record.py
@@ -181,6 +181,7 @@ def api_validation(args=None):
     https://www.memset.com/apidocs/methods_dns.html#dns.zone_record_create)
     '''
     failed_validation = False
+    error = None
 
     # priority can only be integer 0 > 999
     if not 0 <= args['priority'] <= 999:

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -740,6 +740,8 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                 # If not, we have proxmox create one using the special syntax
                 except Exception:
                     vol_string = "{storage}:{size}".format(storage=storage, size=size)
+            else:
+                raise AssertionError('Internal error')
 
             # 1.3 If we have a host_path, we don't have storage, a volume, or a size
             vol_string = ",".join(

--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -544,6 +544,7 @@ class ProxmoxDiskAnsible(ProxmoxAnsible):
             # NOOP
             return False, "Disk %s not found in VM %s and creation was disabled in parameters." % (disk, vmid)
 
+        timeout_str = "Reached timeout. Last line in task before timeout: %s"
         if (create == 'regular' and disk not in vm_config) or (create == 'forced'):
             # CREATE
             playbook_config = self.get_create_attributes()

--- a/plugins/modules/snmp_facts.py
+++ b/plugins/modules/snmp_facts.py
@@ -307,6 +307,8 @@ def main():
         if m_args['community'] is None:
             module.fail_json(msg='Community not set when using snmp version 2')
 
+    integrity_proto = None
+    privacy_proto = None
     if m_args['version'] == "v3":
         if m_args['username'] is None:
             module.fail_json(msg='Username not set when using snmp version 3')

--- a/tests/integration/targets/django_manage/tasks/main.yaml
+++ b/tests/integration/targets/django_manage/tasks/main.yaml
@@ -9,17 +9,10 @@
     suffix: .django_manage
   register: tmp_django_root
 
-- name: Install virtualenv on CentOS 8
+- name: Install virtualenv
   package:
-    name: virtualenv
+    name: "{{ os_package_name.virtualenv }}"
     state: present
-  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '8'
-
-- name: Install virtualenv on Arch Linux
-  pip:
-    name: virtualenv
-    state: present
-  when: ansible_os_family == 'Archlinux'
 
 - name: Install required library
   pip:

--- a/tests/integration/targets/gandi_livedns/aliases
+++ b/tests/integration/targets/gandi_livedns/aliases
@@ -2,5 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-cloud/gandi
 unsupported

--- a/tests/integration/targets/locale_gen/vars/main.yml
+++ b/tests/integration/targets/locale_gen/vars/main.yml
@@ -15,3 +15,12 @@ locale_list_basic:
   - localegen: eo
     locales: [eo]
     skip_removal: false
+  - localegen:
+      - ar_BH.UTF-8
+      - tr_CY.UTF-8
+    locales:
+      - ar_BH.UTF-8
+      - ar_BH.utf8
+      - tr_CY.UTF-8
+      - tr_CY.utf8
+    skip_removal: false

--- a/tests/integration/targets/pipx/tasks/main.yml
+++ b/tests/integration/targets/pipx/tasks/main.yml
@@ -171,7 +171,7 @@
     state: latest
   register: install_tox_latest_with_preinstall_again
 
-- name: install application latest tox
+- name: install application latest tox (force)
   community.general.pipx:
     name: tox
     state: latest
@@ -339,3 +339,36 @@
   assert:
     that:
       - install_pyinstaller is changed
+
+##############################################################################
+# Test for issue 8656
+- name: ensure application conan2 is uninstalled
+  community.general.pipx:
+    name: conan2
+    state: absent
+
+- name: Install Python Package conan with suffix 2 (conan2)
+  community.general.pipx:
+    name: conan
+    state: install
+    suffix: "2"
+  register: install_conan2
+
+- name: Install Python Package conan with suffix 2 (conan2) again
+  community.general.pipx:
+    name: conan
+    state: install
+    suffix: "2"
+  register: install_conan2_again
+
+- name: cleanup conan2
+  community.general.pipx:
+    name: conan2
+    state: absent
+
+- name: check assertions
+  assert:
+    that:
+      - install_conan2 is changed
+      - "'    - conan2' in install_conan2.stdout"
+      - install_conan2_again is not changed

--- a/tests/integration/targets/setup_os_pkg_name/tasks/alpine.yml
+++ b/tests/integration/targets/setup_os_pkg_name/tasks/alpine.yml
@@ -1,0 +1,11 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Update OS Package name fact (alpine)
+  ansible.builtin.set_fact:
+    os_package_name: "{{ os_package_name | combine(specific_package_names) }}"
+  vars:
+    specific_package_names:
+      virtualenv: py3-virtualenv

--- a/tests/integration/targets/setup_os_pkg_name/tasks/archlinux.yml
+++ b/tests/integration/targets/setup_os_pkg_name/tasks/archlinux.yml
@@ -1,0 +1,11 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Update OS Package name fact (archlinux)
+  ansible.builtin.set_fact:
+    os_package_name: "{{ os_package_name | combine(specific_package_names) }}"
+  vars:
+    specific_package_names:
+      virtualenv: python-virtualenv

--- a/tests/integration/targets/setup_os_pkg_name/tasks/debian.yml
+++ b/tests/integration/targets/setup_os_pkg_name/tasks/debian.yml
@@ -3,6 +3,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-dependencies:
-  - setup_pkg_mgr
-  - setup_os_pkg_name
+- name: Update OS Package name fact (debian)
+  ansible.builtin.set_fact:
+    os_package_name: "{{ os_package_name | combine(specific_package_names) }}"
+  vars:
+    specific_package_names: {}

--- a/tests/integration/targets/setup_os_pkg_name/tasks/default.yml
+++ b/tests/integration/targets/setup_os_pkg_name/tasks/default.yml
@@ -1,0 +1,11 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Update OS Package name fact (default)
+  ansible.builtin.set_fact:
+    os_package_name: "{{ os_package_name | combine(specific_package_names) }}"
+  vars:
+    specific_package_names:
+      virtualenv: virtualenv

--- a/tests/integration/targets/setup_os_pkg_name/tasks/main.yml
+++ b/tests/integration/targets/setup_os_pkg_name/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Make sure we have the ansible_os_family and ansible_distribution_version facts
+  ansible.builtin.setup:
+    gather_subset: distribution
+  when: ansible_facts == {}
+
+- name: Create OS Package name fact
+  ansible.builtin.set_fact:
+    os_package_name: {}
+
+- name: Include the files setting the package names
+  ansible.builtin.include_tasks: "{{ file }}"
+  loop_control:
+    loop_var: file
+  loop:
+    - "default.yml"
+    - "{{ ansible_os_family | lower }}.yml"

--- a/tests/integration/targets/setup_os_pkg_name/tasks/redhat.yml
+++ b/tests/integration/targets/setup_os_pkg_name/tasks/redhat.yml
@@ -3,6 +3,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-dependencies:
-  - setup_pkg_mgr
-  - setup_os_pkg_name
+- name: Update OS Package name fact (redhat)
+  ansible.builtin.set_fact:
+    os_package_name: "{{ os_package_name | combine(specific_package_names) }}"
+  vars:
+    specific_package_names: {}

--- a/tests/integration/targets/setup_os_pkg_name/tasks/suse.yml
+++ b/tests/integration/targets/setup_os_pkg_name/tasks/suse.yml
@@ -1,0 +1,11 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Update OS Package name fact (suse)
+  ansible.builtin.set_fact:
+    os_package_name: "{{ os_package_name | combine(specific_package_names) }}"
+  vars:
+    specific_package_names:
+      virtualenv: python3-virtualenv

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -37,7 +37,7 @@ def get_auth():
 
 # NOTE: when updating/adding replies to this function,
 # be sure to only add only the _contents_ of the 'data' dict in the API reply
-def get_json(url):
+def get_json(url, ignore_errors=None):
     if url == "https://localhost:8006/api2/json/nodes":
         # _get_nodes
         return [{"type": "node",

--- a/tests/unit/plugins/inventory/test_xen_orchestra.py
+++ b/tests/unit/plugins/inventory/test_xen_orchestra.py
@@ -146,7 +146,7 @@ def serialize_groups(groups):
     return list(map(str, groups))
 
 
-@ pytest.fixture(scope="module")
+@pytest.fixture(scope="module")
 def inventory():
     r = InventoryModule()
     r.inventory = InventoryData()

--- a/tests/unit/plugins/modules/test_keycloak_identity_provider.py
+++ b/tests/unit/plugins/modules/test_keycloak_identity_provider.py
@@ -23,7 +23,7 @@ from ansible.module_utils.six import StringIO
 @contextmanager
 def patch_keycloak_api(get_identity_provider, create_identity_provider=None, update_identity_provider=None, delete_identity_provider=None,
                        get_identity_provider_mappers=None, create_identity_provider_mapper=None, update_identity_provider_mapper=None,
-                       delete_identity_provider_mapper=None):
+                       delete_identity_provider_mapper=None, get_realm_by_id=None):
     """Mock context manager for patching the methods in PwPolicyIPAClient that contact the IPA server
 
     Patches the `login` and `_post_json` methods
@@ -55,9 +55,11 @@ def patch_keycloak_api(get_identity_provider, create_identity_provider=None, upd
                                     as mock_update_identity_provider_mapper:
                                 with patch.object(obj, 'delete_identity_provider_mapper', side_effect=delete_identity_provider_mapper) \
                                         as mock_delete_identity_provider_mapper:
-                                    yield mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, \
-                                        mock_delete_identity_provider, mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, \
-                                        mock_update_identity_provider_mapper, mock_delete_identity_provider_mapper
+                                    with patch.object(obj, 'get_realm_by_id', side_effect=get_realm_by_id) \
+                                            as mock_get_realm_by_id:
+                                        yield mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, \
+                                            mock_delete_identity_provider, mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, \
+                                            mock_update_identity_provider_mapper, mock_delete_identity_provider_mapper, mock_get_realm_by_id
 
 
 def get_response(object_with_future_response, method, get_id_call_count):
@@ -200,6 +202,38 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
                 "name": "last_name"
             }]
         ]
+        return_value_realm_get = [
+            {
+                'id': 'realm-name',
+                'realm': 'realm-name',
+                'enabled': True,
+                'identityProviders': [
+                    {
+                        "addReadTokenRoleOnCreate": False,
+                        "alias": "oidc-idp",
+                        "authenticateByDefault": False,
+                        "config": {
+                            "authorizationUrl": "https://idp.example.com/auth",
+                            "clientAuthMethod": "client_secret_post",
+                            "clientId": "my-client",
+                            "clientSecret": "secret",
+                            "issuer": "https://idp.example.com",
+                            "syncMode": "FORCE",
+                            "tokenUrl": "https://idp.example.com/token",
+                            "userInfoUrl": "https://idp.example.com/userinfo"
+                        },
+                        "displayName": "OpenID Connect IdP",
+                        "enabled": True,
+                        "firstBrokerLoginFlowAlias": "first broker login",
+                        "internalId": "7ab437d5-f2bb-4ecc-91a8-315349454da6",
+                        "linkOnly": False,
+                        "providerId": "oidc",
+                        "storeToken": False,
+                        "trustEmail": False,
+                    }
+                ]
+            },
+        ]
         return_value_idp_created = [None]
         return_value_mapper_created = [None, None]
         changed = True
@@ -210,15 +244,17 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
-                                    create_identity_provider=return_value_idp_created, create_identity_provider_mapper=return_value_mapper_created) \
+                                    create_identity_provider=return_value_idp_created, create_identity_provider_mapper=return_value_mapper_created,
+                                    get_realm_by_id=return_value_realm_get) \
                     as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
                         mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
-                        mock_delete_identity_provider_mapper):
+                        mock_delete_identity_provider_mapper, mock_get_realm_by_id):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
         self.assertEqual(len(mock_get_identity_provider.mock_calls), 2)
         self.assertEqual(len(mock_get_identity_provider_mappers.mock_calls), 1)
+        self.assertEqual(len(mock_get_realm_by_id.mock_calls), 1)
         self.assertEqual(len(mock_create_identity_provider.mock_calls), 1)
         self.assertEqual(len(mock_create_identity_provider_mapper.mock_calls), 2)
 
@@ -444,6 +480,68 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
                 "name": "last_name"
             }]
         ]
+        return_value_realm_get = [
+            {
+                'id': 'realm-name',
+                'realm': 'realm-name',
+                'enabled': True,
+                'identityProviders': [
+                    {
+                        "addReadTokenRoleOnCreate": False,
+                        "alias": "oidc-idp",
+                        "authenticateByDefault": False,
+                        "config": {
+                            "authorizationUrl": "https://idp.example.com/auth",
+                            "clientAuthMethod": "client_secret_post",
+                            "clientId": "my-client",
+                            "clientSecret": "secret",
+                            "issuer": "https://idp.example.com",
+                            "syncMode": "FORCE",
+                            "tokenUrl": "https://idp.example.com/token",
+                            "userInfoUrl": "https://idp.example.com/userinfo"
+                        },
+                        "displayName": "OpenID Connect IdP",
+                        "enabled": True,
+                        "firstBrokerLoginFlowAlias": "first broker login",
+                        "internalId": "7ab437d5-f2bb-4ecc-91a8-315349454da6",
+                        "linkOnly": False,
+                        "providerId": "oidc",
+                        "storeToken": False,
+                        "trustEmail": False,
+                    }
+                ]
+            },
+            {
+                'id': 'realm-name',
+                'realm': 'realm-name',
+                'enabled': True,
+                'identityProviders': [
+                    {
+                        "addReadTokenRoleOnCreate": False,
+                        "alias": "oidc-idp",
+                        "authenticateByDefault": False,
+                        "config": {
+                            "authorizationUrl": "https://idp.example.com/auth",
+                            "clientAuthMethod": "client_secret_post",
+                            "clientId": "my-client",
+                            "clientSecret": "secret",
+                            "issuer": "https://idp.example.com",
+                            "syncMode": "FORCE",
+                            "tokenUrl": "https://idp.example.com/token",
+                            "userInfoUrl": "https://idp.example.com/userinfo"
+                        },
+                        "displayName": "OpenID Connect IdP",
+                        "enabled": True,
+                        "firstBrokerLoginFlowAlias": "first broker login",
+                        "internalId": "7ab437d5-f2bb-4ecc-91a8-315349454da6",
+                        "linkOnly": False,
+                        "providerId": "oidc",
+                        "storeToken": False,
+                        "trustEmail": False,
+                    }
+                ]
+            },
+        ]
         return_value_idp_updated = [None]
         return_value_mapper_updated = [None]
         return_value_mapper_created = [None]
@@ -456,18 +554,169 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
         with mock_good_connection():
             with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
                                     update_identity_provider=return_value_idp_updated, update_identity_provider_mapper=return_value_mapper_updated,
-                                    create_identity_provider_mapper=return_value_mapper_created) \
+                                    create_identity_provider_mapper=return_value_mapper_created, get_realm_by_id=return_value_realm_get) \
                     as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
                         mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
-                        mock_delete_identity_provider_mapper):
+                        mock_delete_identity_provider_mapper, mock_get_realm_by_id):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
         self.assertEqual(len(mock_get_identity_provider.mock_calls), 2)
         self.assertEqual(len(mock_get_identity_provider_mappers.mock_calls), 5)
+        self.assertEqual(len(mock_get_realm_by_id.mock_calls), 2)
         self.assertEqual(len(mock_update_identity_provider.mock_calls), 1)
         self.assertEqual(len(mock_update_identity_provider_mapper.mock_calls), 1)
         self.assertEqual(len(mock_create_identity_provider_mapper.mock_calls), 1)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+    def test_no_change_when_present(self):
+        """Update existing identity provider"""
+
+        module_args = {
+            'auth_keycloak_url': 'http://keycloak.url/auth',
+            'auth_password': 'admin',
+            'auth_realm': 'master',
+            'auth_username': 'admin',
+            'auth_client_id': 'admin-cli',
+            "addReadTokenRoleOnCreate": False,
+            "alias": "oidc-idp",
+            "authenticateByDefault": False,
+            "config": {
+                "authorizationUrl": "https://idp.example.com/auth",
+                "clientAuthMethod": "client_secret_post",
+                "clientId": "my-client",
+                "clientSecret": "secret",
+                "issuer": "https://idp.example.com",
+                "syncMode": "FORCE",
+                "tokenUrl": "https://idp.example.com/token",
+                "userInfoUrl": "https://idp.example.com/userinfo"
+            },
+            "displayName": "OpenID Connect IdP changeme",
+            "enabled": True,
+            "firstBrokerLoginFlowAlias": "first broker login",
+            "linkOnly": False,
+            "providerId": "oidc",
+            "storeToken": False,
+            "trustEmail": False,
+            'mappers': [{
+                'name': "username",
+                'identityProviderAlias': "oidc-idp",
+                'identityProviderMapper': "oidc-user-attribute-idp-mapper",
+                'config': {
+                    'claim': "username",
+                    'user.attribute': "username",
+                    'syncMode': "INHERIT",
+                }
+            }]
+        }
+        return_value_idp_get = [
+            {
+                "addReadTokenRoleOnCreate": False,
+                "alias": "oidc-idp",
+                "authenticateByDefault": False,
+                "config": {
+                    "authorizationUrl": "https://idp.example.com/auth",
+                    "clientAuthMethod": "client_secret_post",
+                    "clientId": "my-client",
+                    "clientSecret": "**********",
+                    "issuer": "https://idp.example.com",
+                    "syncMode": "FORCE",
+                    "tokenUrl": "https://idp.example.com/token",
+                    "userInfoUrl": "https://idp.example.com/userinfo"
+                },
+                "displayName": "OpenID Connect IdP changeme",
+                "enabled": True,
+                "firstBrokerLoginFlowAlias": "first broker login",
+                "internalId": "7ab437d5-f2bb-4ecc-91a8-315349454da6",
+                "linkOnly": False,
+                "providerId": "oidc",
+                "storeToken": False,
+                "trustEmail": False,
+            },
+        ]
+        return_value_mappers_get = [
+            [{
+                'config': {
+                    'claim': "username",
+                    'syncMode': "INHERIT",
+                    'user.attribute': "username"
+                },
+                "id": "616f11ba-b9ae-42ae-bd1b-bc618741c10b",
+                'identityProviderAlias': "oidc-idp",
+                'identityProviderMapper': "oidc-user-attribute-idp-mapper",
+                'name': "username"
+            }],
+            [{
+                'config': {
+                    'claim': "username",
+                    'syncMode': "INHERIT",
+                    'user.attribute': "username"
+                },
+                "id": "616f11ba-b9ae-42ae-bd1b-bc618741c10b",
+                'identityProviderAlias': "oidc-idp",
+                'identityProviderMapper': "oidc-user-attribute-idp-mapper",
+                'name': "username"
+            }]
+        ]
+        return_value_realm_get = [
+            {
+                'id': 'realm-name',
+                'realm': 'realm-name',
+                'enabled': True,
+                'identityProviders': [
+                    {
+                        "addReadTokenRoleOnCreate": False,
+                        "alias": "oidc-idp",
+                        "authenticateByDefault": False,
+                        "config": {
+                            "authorizationUrl": "https://idp.example.com/auth",
+                            "clientAuthMethod": "client_secret_post",
+                            "clientId": "my-client",
+                            "clientSecret": "secret",
+                            "issuer": "https://idp.example.com",
+                            "syncMode": "FORCE",
+                            "tokenUrl": "https://idp.example.com/token",
+                            "userInfoUrl": "https://idp.example.com/userinfo"
+                        },
+                        "displayName": "OpenID Connect IdP",
+                        "enabled": True,
+                        "firstBrokerLoginFlowAlias": "first broker login",
+                        "internalId": "7ab437d5-f2bb-4ecc-91a8-315349454da6",
+                        "linkOnly": False,
+                        "providerId": "oidc",
+                        "storeToken": False,
+                        "trustEmail": False,
+                    }
+                ]
+            }
+        ]
+        return_value_idp_updated = [None]
+        return_value_mapper_updated = [None]
+        return_value_mapper_created = [None]
+        changed = False
+
+        set_module_args(module_args)
+
+        # Run the module
+
+        with mock_good_connection():
+            with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
+                                    update_identity_provider=return_value_idp_updated, update_identity_provider_mapper=return_value_mapper_updated,
+                                    create_identity_provider_mapper=return_value_mapper_created, get_realm_by_id=return_value_realm_get) \
+                    as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
+                        mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
+                        mock_delete_identity_provider_mapper, mock_get_realm_by_id):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        self.assertEqual(len(mock_get_identity_provider.mock_calls), 1)
+        self.assertEqual(len(mock_get_identity_provider_mappers.mock_calls), 2)
+        self.assertEqual(len(mock_get_realm_by_id.mock_calls), 1)
+        self.assertEqual(len(mock_update_identity_provider.mock_calls), 0)
+        self.assertEqual(len(mock_update_identity_provider_mapper.mock_calls), 0)
+        self.assertEqual(len(mock_create_identity_provider_mapper.mock_calls), 0)
 
         # Verify that the module's changed status matches what is expected
         self.assertIs(exec_info.exception.args[0]['changed'], changed)
@@ -497,7 +746,7 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
             with patch_keycloak_api(get_identity_provider=return_value_idp_get) \
                     as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
                         mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
-                        mock_delete_identity_provider_mapper):
+                        mock_delete_identity_provider_mapper, mock_get_realm_by_id):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
@@ -560,6 +809,38 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
                 "name": "email"
             }]
         ]
+        return_value_realm_get = [
+            {
+                'id': 'realm-name',
+                'realm': 'realm-name',
+                'enabled': True,
+                'identityProviders': [
+                    {
+                        "alias": "oidc",
+                        "displayName": "",
+                        "internalId": "2bca4192-e816-4beb-bcba-190164eb55b8",
+                        "providerId": "oidc",
+                        "enabled": True,
+                        "updateProfileFirstLoginMode": "on",
+                        "trustEmail": False,
+                        "storeToken": False,
+                        "addReadTokenRoleOnCreate": False,
+                        "authenticateByDefault": False,
+                        "linkOnly": False,
+                        "config": {
+                            "validateSignature": "false",
+                            "pkceEnabled": "false",
+                            "tokenUrl": "https://localhost:8000",
+                            "clientId": "asdf",
+                            "authorizationUrl": "https://localhost:8000",
+                            "clientAuthMethod": "client_secret_post",
+                            "clientSecret": "real_secret",
+                            "guiOrder": "0"
+                        }
+                    },
+                ]
+            },
+        ]
         return_value_idp_deleted = [None]
         changed = True
 
@@ -569,15 +850,16 @@ class TestKeycloakIdentityProvider(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_identity_provider=return_value_idp_get, get_identity_provider_mappers=return_value_mappers_get,
-                                    delete_identity_provider=return_value_idp_deleted) \
+                                    delete_identity_provider=return_value_idp_deleted, get_realm_by_id=return_value_realm_get) \
                     as (mock_get_identity_provider, mock_create_identity_provider, mock_update_identity_provider, mock_delete_identity_provider,
                         mock_get_identity_provider_mappers, mock_create_identity_provider_mapper, mock_update_identity_provider_mapper,
-                        mock_delete_identity_provider_mapper):
+                        mock_delete_identity_provider_mapper, mock_get_realm_by_id):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
         self.assertEqual(len(mock_get_identity_provider.mock_calls), 1)
         self.assertEqual(len(mock_get_identity_provider_mappers.mock_calls), 1)
+        self.assertEqual(len(mock_get_realm_by_id.mock_calls), 1)
         self.assertEqual(len(mock_delete_identity_provider.mock_calls), 1)
 
         # Verify that the module's changed status matches what is expected

--- a/tests/unit/plugins/modules/test_keycloak_user_federation.py
+++ b/tests/unit/plugins/modules/test_keycloak_user_federation.py
@@ -144,8 +144,9 @@ class TestKeycloakUserFederation(ModuleTestCase):
                 }
             }
         ]
+        # get before_comp, get default_mapper, get after_mapper
         return_value_components_get = [
-            [], []
+            [], [], []
         ]
         changed = True
 
@@ -159,7 +160,7 @@ class TestKeycloakUserFederation(ModuleTestCase):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
-        self.assertEqual(len(mock_get_components.mock_calls), 1)
+        self.assertEqual(len(mock_get_components.mock_calls), 3)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
         self.assertEqual(len(mock_create_component.mock_calls), 1)
         self.assertEqual(len(mock_update_component.mock_calls), 0)
@@ -228,6 +229,7 @@ class TestKeycloakUserFederation(ModuleTestCase):
                     }
                 }
             ],
+            [],
             []
         ]
         return_value_component_get = [
@@ -281,7 +283,7 @@ class TestKeycloakUserFederation(ModuleTestCase):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
-        self.assertEqual(len(mock_get_components.mock_calls), 2)
+        self.assertEqual(len(mock_get_components.mock_calls), 3)
         self.assertEqual(len(mock_get_component.mock_calls), 1)
         self.assertEqual(len(mock_create_component.mock_calls), 0)
         self.assertEqual(len(mock_update_component.mock_calls), 1)
@@ -344,7 +346,47 @@ class TestKeycloakUserFederation(ModuleTestCase):
             ]
         }
         return_value_components_get = [
-            [], []
+            [],
+            # exemplary default mapper created by keylocak
+            [
+                {
+                    "config": {
+                        "always.read.value.from.ldap": "false",
+                        "is.mandatory.in.ldap": "false",
+                        "ldap.attribute": "mail",
+                        "read.only": "true",
+                        "user.model.attribute": "email"
+                    },
+                    "id": "77e1763f-c51a-4286-bade-75577d64803c",
+                    "name": "email",
+                    "parentId": "e5f48aa3-b56b-4983-a8ad-2c7b8b5e77cb",
+                    "providerId": "user-attribute-ldap-mapper",
+                    "providerType": "org.keycloak.storage.ldap.mappers.LDAPStorageMapper"
+                },
+            ],
+            [
+                {
+                    "id": "2dfadafd-8b34-495f-a98b-153e71a22311",
+                    "name": "full name",
+                    "providerId": "full-name-ldap-mapper",
+                    "providerType": "org.keycloak.storage.ldap.mappers.LDAPStorageMapper",
+                    "parentId": "eb691537-b73c-4cd8-b481-6031c26499d8",
+                    "config": {
+                        "ldap.full.name.attribute": [
+                            "cn"
+                        ],
+                        "read.only": [
+                            "true"
+                        ],
+                        "write.only": [
+                            "false"
+                        ]
+                    }
+                }
+            ]
+        ]
+        return_value_component_delete = [
+            None
         ]
         return_value_component_create = [
             {
@@ -462,11 +504,11 @@ class TestKeycloakUserFederation(ModuleTestCase):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
-        self.assertEqual(len(mock_get_components.mock_calls), 2)
+        self.assertEqual(len(mock_get_components.mock_calls), 3)
         self.assertEqual(len(mock_get_component.mock_calls), 0)
         self.assertEqual(len(mock_create_component.mock_calls), 2)
         self.assertEqual(len(mock_update_component.mock_calls), 0)
-        self.assertEqual(len(mock_delete_component.mock_calls), 0)
+        self.assertEqual(len(mock_delete_component.mock_calls), 1)
 
         # Verify that the module's changed status matches what is expected
         self.assertIs(exec_info.exception.args[0]['changed'], changed)


### PR DESCRIPTION
##### SUMMARY
- `one_vnet` module to manage networks in OpenNebula

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- New Module/Plugin Pull Request

##### COMPONENT NAME
one_vnet

##### ADDITIONAL INFORMATION
There were no option to configure network using modules which is important
I used other `one_*` modules to make it similar, especially `one_template` which i used as a base
xml-rpc schemes:
https://github.com/privazio/pyone/blob/master/pyone/xsd/vnet.xsd
https://github.com/privazio/pyone/blob/master/pyone/xsd/vnet_pool.xsd
opennebula docs:
https://docs.opennebula.io/6.8/integration_and_development/system_interfaces/api.html
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Fetch the TEMPLATE by name
  community.general.one_vnet:
    name: opennebula-bridge
  register: result

- name: Create a new or update an existing NETWORK
  community.general.one_vnet:
    name: bridge-network
    template: |
      VN_MAD  = "bridge"
      BRIDGE  = "br0"
      BRIDGE_TYPE  = "linux"
      AR=[
        TYPE  = "IP4",
        IP    = 192.0.2.50,
        SIZE  = "20"
      ]
      DNS     = 192.0.2.1
      GATEWAY = 192.0.2.1
```
